### PR TITLE
Ensure paw-gps works when default values are used.

### DIFF
--- a/pwnagotchi/plugins/default/paw-gps.py
+++ b/pwnagotchi/plugins/default/paw-gps.py
@@ -10,25 +10,30 @@ GUIDE HERE: https://community.pwnagotchi.ai/t/setting-up-paw-gps-on-android
 
 class PawGPS(plugins.Plugin):
     __author__ = 'leont'
-    __version__ = '1.0.0'
+    __version__ = '1.0.1'
     __name__ = 'pawgps'
     __license__ = 'GPL3'
-    __description__ = 'Saves GPS coordinates whenever an handshake is captured. The GPS data is get from PAW on android '
+    __description__ = 'Saves GPS coordinates whenever an handshake is captured. The GPS data is get from PAW on android.'
 
     def on_loaded(self):
-        logging.info("PAW-GPS loaded")
-        if 'ip' not in self.options or ('ip' in self.options and self.options['ip'] is None):
-            logging.info("PAW-GPS: No IP Address in the config file is defined, it uses the default (192.168.44.1:8080)")
+        logging.info("[paw-gps] plugin loaded")
+        if 'ip' not in self.options or ('ip' in self.options and self.options['ip'] is None) or (len('ip' in self.options and self.options['ip']) is 0):
+            logging.info("[paw-gps] no IP Address defined in the config file, will uses paw server default (192.168.44.1:8080)")
 
     def on_handshake(self, agent, filename, access_point, client_station):
-        if 'ip' not in self.options or ('ip' in self.options and self.options['ip'] is None):
+        if 'ip' not in self.options or ('ip' in self.options and self.options['ip'] is None or (len('ip' in self.options and self.options['ip']) is 0)):
             ip = "192.168.44.1:8080"
         else:
             ip = self.options['ip']
 
-        gps = requests.get('http://' + ip + '/gps.xhtml')
-        gps_filename = filename.replace('.pcap', '.paw-gps.json')
-
-        logging.info("saving GPS to %s (%s)" % (gps_filename, gps))
-        with open(gps_filename, 'w+t') as f:
-            f.write(gps.text)
+        try:
+            gps = requests.get('http://' + ip + '/gps.xhtml')
+            try:
+                gps_filename = filename.replace('.pcap', '.paw-gps.json')
+                logging.info("[paw-gps] saving GPS data to %s" % (gps_filename))
+                with open(gps_filename, 'w+t') as f:
+                    f.write(gps.text)
+            except Exception as error:
+                logging.error(f"[paw-gps] encountered error while saving gps data: {error}")
+        except Exception as error:
+            logging.error(f"[paw-gps] encountered error while getting gps data: {error}")


### PR DESCRIPTION
Ensures sane defaults are used for paw-gps plugin.
Implements additional check for the value of `self.options['ip']` to avoid empty strings breaking the plugin.
Implements error handling for more detailed error logs.

## Description
The default.toml file contains the following default value for the IP of paw-gps `plugin main.plugins.paw-gps.ip = ""`.

The current plugin uses the following logic to determine what value it should use by default. This logic does not handle the default empty string, meaning IP is never set to the intended default value.

```python
def on_loaded(self):
        logging.info("PAW-GPS loaded")
        if 'ip' not in self.options or ('ip' in self.options and self.options['ip'] is None):
            logging.info("PAW-GPS: No IP Address in the config file is defined, it uses the default (192.168.44.1:8080)")

    def on_handshake(self, agent, filename, access_point, client_station):
        if 'ip' not in self.options or ('ip' in self.options and self.options['ip'] is None):
            ip = "192.168.44.1:8080"
        else:
            ip = self.options['ip']
```

Additionally no error logs are created when the plugin is unable to reach the paw server.

## Motivation and Context

Plugin should 'just' work using default settings after enabling and not require troubleshooting/inspecting logs.
When the plugin is incorrectly configured/is unable to perform its action it should log detailed (enough) errors to figure out what went wrong in a eye glans.

- [x] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

https://github.com/evilsocket/pwnagotchi/issues/1053

## How Has This Been Tested?

Trying to get the plugin to work while setting up a fresh pwnagotchi. Updated the plugin and pip installed the updated version. Ran pwnagotchi and verified the plugin now works as intended with the default values from default.toml.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
